### PR TITLE
Write the frame scene and detecting result files.

### DIFF
--- a/container-batch-inference/resources/FairMOT/predict.py
+++ b/container-batch-inference/resources/FairMOT/predict.py
@@ -85,9 +85,8 @@ def infer_video(vpath, width, height):
     
     fourcc = cv2.VideoWriter_fourcc(*'MP4V')
     output_mp4 = os.path.join('/opt/ml/processing/output', vpath.split('/')[-1])
-    output_jpg = os.path.join('/opt/ml/processing/output', 'jpgs')
-    output_txt = os.path.join('/opt/ml/processing/output', 'results')
-    mkdir_if_missing(output_txt)
+    output_jpg = os.path.join('/opt/ml/processing/output', vpath.split('/')[-1].split('.')[-2], 'jpgs')
+    output_txt = os.path.join('/opt/ml/processing/output', vpath.split('/')[-1].split('.')[-2])
     mkdir_if_missing(output_jpg)
     print(f'output_mp4_path : {output_mp4} width: {width}, height: {height}')
     print(f'output_txt_path : {output_txt}')
@@ -99,7 +98,8 @@ def infer_video(vpath, width, height):
     
     while True:
         ret, frame = cap.read()
-out_            break
+        if ret != True:
+            break
         
         online_targets = tracker.update([frame])
         online_tlwhs = []
@@ -108,6 +108,7 @@ out_            break
         for i in online_targets[0]:
             online_ids.append(i)
             online_tlwhs.append(online_targets[0][i])
+        results.append((frame_id + 1, online_tlwhs, online_ids))
         
         # save video
         frame_res = draw_res(online_targets[0], frame, frame_id, width)
@@ -118,9 +119,8 @@ out_            break
         # save frame
         cv2.imwrite(os.path.join(output_jpg, '{:05d}.jpg'.format(frame_id)), frame)
     
-    results.append((frame_id + 1, online_tlwhs, online_ids))
     # save results
-    output_file = os.path.join(output_txt, '{:05d}.txt'.format(frame_id))
+    output_file=output_txt + '/results.txt'
     write_results(output_file, results)
     
     out.release()
@@ -149,7 +149,7 @@ def main():
     video_info = check_data()
     for k, v in video_info.items():
         infer_video(k, v['width'], v['height'])
-    print("Finishing inferecne job after storing the output")
+    print("... finishing inferecne job after storing the output")
 
 if __name__ == "__main__":
     main()

--- a/container-batch-inference/resources/FairMOT/predict.py
+++ b/container-batch-inference/resources/FairMOT/predict.py
@@ -12,6 +12,8 @@ from tracker.multitracker import JDETracker
 from config import Config
 import cv2
 import numpy as np
+import os.path as osp
+import time
 
 def get_color(idx):
     idx = idx * 3
@@ -56,28 +58,70 @@ class FairMOTService:
 
         cls.trakcer = JDETracker(config, batch_size=batch_size)
         return cls.trakcer
+        
+def write_results(filename, results):
+    save_format = '{frame},{id},{x1},{y1},{w},{h},1,-1,-1,-1\n'
 
+    with open(filename, 'w') as f:
+        for frame_id, tlwhs, track_ids in results:
+            for tlwh, track_id in zip(tlwhs, track_ids):
+                if track_id < 0:
+                    continue
+                x1, y1, w, h = tlwh
+                x2, y2 = x1 + w, y1 + h
+                line = save_format.format(frame=frame_id, id=track_id, x1=x1, y1=y1, x2=x2, y2=y2, w=w, h=h)
+                f.write(line)
+    # logger.info('save results to {}'.format(filename))
+
+def mkdir_if_missing(d):
+    if not osp.exists(d):
+        os.makedirs(d)
+
+        
 def infer_video(vpath, width, height):
     tracker = FairMOTService.create_tracker(frame_w=width, frame_h=height)
     
     cap = cv2.VideoCapture(vpath)
     
     fourcc = cv2.VideoWriter_fourcc(*'MP4V')
-    output_path = os.path.join('/opt/ml/processing/output', vpath.split('/')[-1])
-    print(f'output_path: {output_path} width: {width}, height: {height}')
-    out = cv2.VideoWriter(output_path, fourcc, 25, (width, height))
-    
+    output_mp4 = os.path.join('/opt/ml/processing/output', vpath.split('/')[-1])
+    output_jpg = os.path.join('/opt/ml/processing/output', 'jpgs')
+    output_txt = os.path.join('/opt/ml/processing/output', 'results')
+    mkdir_if_missing(output_txt)
+    mkdir_if_missing(output_jpg)
+    print(f'output_mp4_path : {output_mp4} width: {width}, height: {height}')
+    print(f'output_txt_path : {output_txt}')
+    print(f'output_jpg_path : {output_jpg}')
+
+    out = cv2.VideoWriter(output_mp4, fourcc, 25, (width, height))
+    results = []
     frame_id = 0
+    
     while True:
         ret, frame = cap.read()
-        if ret != True:
-            break
+out_            break
         
         online_targets = tracker.update([frame])
+        online_tlwhs = []
+        online_ids = []
+
+        for i in online_targets[0]:
+            online_ids.append(i)
+            online_tlwhs.append(online_targets[0][i])
+        
+        # save video
         frame_res = draw_res(online_targets[0], frame, frame_id, width)
         out.write(frame_res)
+        
         frame_id += 1
         print(f'frame-{frame_id}')
+        # save frame
+        cv2.imwrite(os.path.join(output_jpg, '{:05d}.jpg'.format(frame_id)), frame)
+    
+    results.append((frame_id + 1, online_tlwhs, online_ids))
+    # save results
+    output_file = os.path.join(output_txt, '{:05d}.txt'.format(frame_id))
+    write_results(output_file, results)
     
     out.release()
     cap.release()
@@ -105,6 +149,7 @@ def main():
     video_info = check_data()
     for k, v in video_info.items():
         infer_video(k, v['width'], v['height'])
+    print("Finishing inferecne job after storing the output")
 
 if __name__ == "__main__":
     main()

--- a/fairmot-batch-inference.ipynb
+++ b/fairmot-batch-inference.ipynb
@@ -170,7 +170,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "bucket_name = # your-s3-bucket-name\n",
+    "bucket_name = sagemaker.Session().default_bucket() \n",
     "\n",
     "# Restore the s3 uri of the trained model\n",
     "%store -r s3_model_uri\n",
@@ -236,9 +236,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "conda_tensorflow_p36",
+   "display_name": "conda_pytorch_p39",
    "language": "python",
-   "name": "conda_tensorflow_p36"
+   "name": "conda_pytorch_p39"
   },
   "language_info": {
    "codemirror_mode": {
@@ -250,7 +250,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.13"
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,

--- a/fairmot-training.ipynb
+++ b/fairmot-training.ipynb
@@ -59,7 +59,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "s3_bucket = # your-s3-bucket-name\n",
+    "s3_bucket = sagemaker.Session().default_bucket() \n",
     "\n",
     "# we use data parallel to train a model on a single instance as https://github.com/ifzhang/FairMOT\n",
     "version_name = \"dp\"\n",
@@ -703,9 +703,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "conda_tensorflow_p36",
+   "display_name": "conda_pytorch_p39",
    "language": "python",
-   "name": "conda_tensorflow_p36"
+   "name": "conda_pytorch_p39"
   },
   "language_info": {
    "codemirror_mode": {
@@ -717,7 +717,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.13"
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
*Issue #, if available:*
- In batch inference, the original code only writes mp4 video files. However, in real usecases, users need to run re-identification after the multi-object tracking. I added the code to write jpg files of detected scene and bounding box matrics results in text file. 
- I updated the code to use default SageMaker default s3 bucket in order for users not to change the code when their first running. 

*Description of changes:*
- predictor.py : collect id and tlwhs(top, left, whdith, height) comonents from `online_targets` and write these to output txt file in `/opt/ml/processing/output/v-filename/resuts.txt`.
- predictor.py : store detected scene images to the path of `/opt/ml/processing/output/v-filename/jpgs/` folder.
- fairmot-training.ipynb, fairmot-batch-inference.ipynb : updated the blank name of s3 to `sagemaker.Session().default_bucket()`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
